### PR TITLE
feat: implement FUSE HTTP thin client with Bun runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md — Walrus Drive
+
+> **Keep this file up to date.** When introducing changes (new files, architectural decisions, dependency changes, implemented features), update the relevant sections below before finishing the task.
+
+## What is this project?
+
+Walrus Drive is a decentralized Dropbox for macOS. Files dropped into a FUSE-mounted drive get encrypted (Seal), stored on Walrus, and tracked on Sui. The stack:
+
+- **FUSE** → virtual filesystem mounted via `fuse-native` (macFUSE)
+- **Seal** → on-chain encryption policy (encrypt before upload, decrypt after download)
+- **Walrus** → decentralized blob storage
+- **Sui** → on-chain file registry (Move smart contract)
+
+## Runtime & tooling
+
+- **Runtime:** Bun (not Node). Use `bun run`, `bun install`, etc.
+- **Language:** TypeScript — Bun runs `.ts` directly, no compile step needed
+- **Type checking:** `bun run --bun tsc --noEmit` (tsc is type-checker only, `noEmit: true`)
+- **Package manager:** Bun (`bun.lock`, not `package-lock.json`)
+- **Module resolution:** `"moduleResolution": "bundler"` — use `.ts` extensions in imports
+
+## Repository layout
+
+```
+walrus-hackathon-mar-2026/
+├── CLAUDE.md                          # ← you are here
+├── contract/                          # Move smart contract (Sui)
+│   ├── Move.toml
+│   └── sources/walrus_drive.move      # Seal registry: allowlist-based encrypt/decrypt policy
+├── app/                               # TypeScript FUSE daemon
+│   ├── package.json                   # Scripts: start, build, codegen
+│   ├── tsconfig.json                  # Bun-compatible: module=preserve, bundler resolution
+│   └── src/
+│       ├── index.ts                   # Entry point — parses CLI arg, calls mountDrive()
+│       ├── fuse.ts                    # ✅ FUSE HTTP thin client (12 ops → localhost:3001)
+│       ├── types/fuse-native.d.ts     # ✅ TypeScript declarations for fuse-native
+│       ├── db.ts                      # 🔲 Stub — SQLite local cache (will use bun:sqlite)
+│       ├── walrus.ts                  # 🔲 Stub — Walrus blob upload/download
+│       ├── seal.ts                    # 🔲 Stub — Seal encrypt/decrypt
+│       └── sui.ts                     # 🔲 Stub — Sui on-chain file metadata
+├── fuse-plan.md                       # Research notes on FUSE + macOS + TypeScript
+└── .gitignore
+```
+
+Legend: ✅ = implemented, 🔲 = stub/TODO
+
+## Architecture: FUSE ↔ HTTP server split
+
+The FUSE layer is a **thin client** that delegates all operations to a local HTTP server:
+
+```
+┌──────────────┐   HTTP POST (JSON)   ┌──────────────────┐
+│  fuse.ts     │ ──────────────────── │  HTTP server     │
+│  (FUSE ops)  │  localhost:3001      │  (Bun.serve)     │
+│              │ ◄──────────────────── │  db + walrus +   │
+│  kernel ↔ JS │   JSON responses     │  seal + sui      │
+└──────────────┘                      └──────────────────┘
+```
+
+**Why this split:** Makes the FUSE layer independently testable (mock the HTTP server), and separates filesystem concerns from storage/encryption/chain logic.
+
+### HTTP API contract
+
+RPC-style: `POST http://localhost:3001/fuse/{operation}` with JSON bodies.
+
+| Operation  | Request body                                    | Success response               |
+|------------|------------------------------------------------|---------------------------------|
+| `getattr`  | `{ path }`                                      | `{ stat: { mode, size, ... } }` |
+| `readdir`  | `{ path }`                                      | `{ entries: [...] }`            |
+| `open`     | `{ path, flags }`                               | `{ fd }`                        |
+| `read`     | `{ path, fd, length, position }`                | `{ data: "<base64>", bytesRead }` |
+| `write`    | `{ path, fd, data: "<base64>", length, position }` | `{ bytesWritten }`          |
+| `create`   | `{ path, mode }`                                | `{ fd }`                        |
+| `unlink`   | `{ path }`                                      | `{}`                            |
+| `rename`   | `{ src, dest }`                                 | `{}`                            |
+| `mkdir`    | `{ path, mode }`                                | `{}`                            |
+| `rmdir`    | `{ path }`                                      | `{}`                            |
+| `truncate` | `{ path, size }`                                | `{}`                            |
+| `release`  | `{ path, fd }`                                  | `{}`                            |
+
+**Errors:** Non-200 → `{ "error": "ENOENT" }`. Client maps string → `Fuse.ENOENT` etc., fallback `Fuse.EIO`.
+
+## Smart contract (Seal registry)
+
+`contract/sources/walrus_drive.move` — A shared `Registry` object where each user has an allowlist of addresses. The `seal_approve` entry function is the Seal callback: it verifies the namespace prefix matches the registry ID, extracts the owner address, and checks the caller is on the owner's list.
+
+Key functions: `create_list`, `add`, `remove`, `seal_approve`.
+
+## Key patterns & gotchas
+
+- **`read`/`write` callback quirk:** In `fuse-native`, most callbacks are `cb(err, result)`. But `read` and `write` use `cb(bytesTransferred)` — `0` means EOF (not success), negative means error. This is handled in `fuse.ts`.
+- **Binary data over JSON:** `read` responses and `write` requests use base64 encoding for file content.
+- **Fetch timeout:** 30-second `AbortSignal.timeout` prevents FUSE hangs if the server is down.
+- **Graceful unmount:** SIGINT/SIGTERM handlers call `fuse.unmount()` with `diskutil unmount force` fallback.
+- **Type declarations:** `fuse-native` has no built-in types. We use namespace merging in `types/fuse-native.d.ts` so `Fuse.FuseOperations` works alongside `export = Fuse`.
+- **No `better-sqlite3`:** Removed in favor of `bun:sqlite` (built into Bun runtime). `db.ts` is still a stub.
+
+## Commands
+
+```bash
+cd app
+bun install                    # install deps
+bun run start                  # mount FUSE at ./mnt (or pass custom path)
+bun run start /path/to/mount   # mount at custom path
+bun run build                  # type-check only (no JS output)
+bun run codegen                # generate TS bindings from Move contract
+```
+
+## What's next (TODO)
+
+1. **HTTP server** (`app/src/server.ts`) — `Bun.serve()` implementing the API contract above, wiring db + walrus + seal + sui
+2. **SQLite cache** (`app/src/db.ts`) — file tree metadata using `bun:sqlite`
+3. **Walrus client** (`app/src/walrus.ts`) — blob upload/download via Walrus HTTP API
+4. **Seal integration** (`app/src/seal.ts`) — encrypt/decrypt using on-chain policy
+5. **Sui client** (`app/src/sui.ts`) — create/update/delete FileEntry objects on-chain

--- a/app/bun.lock
+++ b/app/bun.lock
@@ -1,0 +1,161 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "walrus-drive",
+      "dependencies": {
+        "@mysten/sui": "^1.0.0",
+        "fuse-native": "^2.2.2",
+      },
+      "devDependencies": {
+        "@mysten/codegen": "^0.8.2",
+        "@types/bun": "^1.2.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" } }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],
+
+    "@0no-co/graphqlsp": ["@0no-co/graphqlsp@1.15.2", "", { "dependencies": { "@gql.tada/internal": "^1.0.0", "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0" }, "peerDependencies": { "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0", "typescript": "^5.0.0" } }, "sha512-Ys031WnS3sTQQBtRTkQsYnw372OlW72ais4sp0oh2UMPRNyxxnq85zRfU4PIdoy9kWriysPT5BYAkgIxhbonFA=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@gql.tada/cli-utils": ["@gql.tada/cli-utils@1.7.2", "", { "dependencies": { "@0no-co/graphqlsp": "^1.12.13", "@gql.tada/internal": "1.0.8", "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0" }, "peerDependencies": { "@0no-co/graphqlsp": "^1.12.13", "@gql.tada/svelte-support": "1.0.1", "@gql.tada/vue-support": "1.0.1", "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0", "typescript": "^5.0.0" }, "optionalPeers": ["@gql.tada/svelte-support", "@gql.tada/vue-support"] }, "sha512-Qbc7hbLvCz6IliIJpJuKJa9p05b2Jona7ov7+qofCsMRxHRZE1kpAmZMvL8JCI4c0IagpIlWNaMizXEQUe8XjQ=="],
+
+    "@gql.tada/internal": ["@gql.tada/internal@1.0.8", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.5" }, "peerDependencies": { "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0", "typescript": "^5.0.0" } }, "sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g=="],
+
+    "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
+
+    "@mysten/bcs": ["@mysten/bcs@2.0.2", "", { "dependencies": { "@mysten/utils": "^0.3.1", "@scure/base": "^2.0.0" } }, "sha512-c/nVRPJEV1fRZdKXhysVsy/yCPdiFt7jn6A4/7W2LH1ZPSVPzRkxtLY362D0zaLuBnyT5Y9d9nFLm3ixI8Goug=="],
+
+    "@mysten/codegen": ["@mysten/codegen@0.8.2", "", { "dependencies": { "@mysten/bcs": "^2.0.2", "@mysten/sui": "^2.3.2", "@stricli/auto-complete": "^1.2.5", "@stricli/core": "^1.2.5", "@types/node": "^25.0.8", "cosmiconfig": "^9.0.0", "prettier": "^3.7.4", "toml": "^3.0.0", "typescript": "^5.9.3", "zod": "^4.3.5" }, "bin": { "__sui-ts-codegen_bash_complete": "dist/bin/bash-complete.mjs", "sui-ts-codegen": "dist/bin/cli.mjs" } }, "sha512-x/m7ony8Cuzph33LUv3Rce86ev+HUDuyjEW7QMyrenoE6oHIvMHtkjxBtVR8ia1gPCYxTCkwRzelHqC6shMr4g=="],
+
+    "@mysten/sui": ["@mysten/sui@1.45.2", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@mysten/bcs": "1.9.2", "@mysten/utils": "0.2.0", "@noble/curves": "=1.9.4", "@noble/hashes": "^1.8.0", "@protobuf-ts/grpcweb-transport": "^2.11.1", "@protobuf-ts/runtime": "^2.11.1", "@protobuf-ts/runtime-rpc": "^2.11.1", "@scure/base": "^1.2.6", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "gql.tada": "^1.8.13", "graphql": "^16.11.0", "poseidon-lite": "0.2.1", "valibot": "^1.2.0" } }, "sha512-gftf7fNpFSiXyfXpbtP2afVEnhc7p2m/MEYc/SO5pov92dacGKOpQIF7etZsGDI1Wvhv+dpph+ulRNpnYSs7Bg=="],
+
+    "@mysten/utils": ["@mysten/utils@0.2.0", "", { "dependencies": { "@scure/base": "^1.2.6" } }, "sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w=="],
+
+    "@noble/curves": ["@noble/curves@1.9.4", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@protobuf-ts/grpcweb-transport": ["@protobuf-ts/grpcweb-transport@2.11.1", "", { "dependencies": { "@protobuf-ts/runtime": "^2.11.1", "@protobuf-ts/runtime-rpc": "^2.11.1" } }, "sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw=="],
+
+    "@protobuf-ts/runtime": ["@protobuf-ts/runtime@2.11.1", "", {}, "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ=="],
+
+    "@protobuf-ts/runtime-rpc": ["@protobuf-ts/runtime-rpc@2.11.1", "", { "dependencies": { "@protobuf-ts/runtime": "^2.11.1" } }, "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ=="],
+
+    "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
+
+    "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
+
+    "@stricli/auto-complete": ["@stricli/auto-complete@1.2.6", "", { "dependencies": { "@stricli/core": "^1.2.6" }, "bin": { "auto-complete": "dist/bin/cli.js" } }, "sha512-H7dectwnLBoyDrp4Vek1gTNdUWzqkEDt5X6oFoOPxPVbca5FA9ttBZ/OlfNvt14aeiZUsg1rC7GEHjIh3tjn2A=="],
+
+    "@stricli/core": ["@stricli/core@1.2.6", "", {}, "sha512-j5fa1wyOLrP9WJqqLFEJeQviqb3cK46K+FXTuISEkG/H5C820YfKDoVQ3CDVdM5WLhEx1ARdpiW6+hU4tYHjCQ=="],
+
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" } }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "fuse-native": ["fuse-native@2.2.6", "", { "dependencies": { "fuse-shared-library": "^1.0.2", "nanoresource": "^1.3.0", "napi-macros": "^2.0.0", "node-gyp-build": "^4.2.0" }, "bin": "bin.js" }, "sha512-Y5wXd7vUsWWWIIHbjluv7jKZgPZaSVA5YWaW3I5fXIJfcGWL6IRUgoBUveQAq+D8cG9cCiGNahv9CeToccCXrw=="],
+
+    "fuse-shared-library": ["fuse-shared-library@1.1.1", "", { "dependencies": { "fuse-shared-library-darwin": "^1.0.3", "fuse-shared-library-linux": "^1.0.1", "fuse-shared-library-linux-arm": "^1.0.0" } }, "sha512-EfgTo/eS1euZFUe7x8KqyA40hV4DwP7kqp1VNZApu2nlPnJv8SanraBE3VXyX7ff41sxw7M0oWY7re3G3wnZVA=="],
+
+    "fuse-shared-library-darwin": ["fuse-shared-library-darwin@1.1.3", "", {}, "sha512-4Q8gMxyMl1+gwHGpiYUoKKpi7xq8WcPo0TvJvjZzHMuCiszouu2GgEs6SJAqPB3LjfmEkl6kPV+2Oluczr0Nig=="],
+
+    "fuse-shared-library-linux": ["fuse-shared-library-linux@1.0.1", "", {}, "sha512-07MQRSobrBKwW4D7oKm0gM2TwgvZWb+gC08JdiYDG4KBTncxk9ssqEDiDMKll8hpseZufsY2w1yc/feOu2DPmQ=="],
+
+    "fuse-shared-library-linux-arm": ["fuse-shared-library-linux-arm@1.0.0", "", {}, "sha512-Dj4ssxo1/MKGvOsVWRblSRu+o5F5OJTrVPDkjSyGDU2yKvVnIzQSwy1deiWA0qCcS/Q8iJMlZaCpCcZWSwvoug=="],
+
+    "gql.tada": ["gql.tada@1.9.0", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.5", "@0no-co/graphqlsp": "^1.12.13", "@gql.tada/cli-utils": "1.7.2", "@gql.tada/internal": "1.0.8" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "gql-tada": "bin/cli.js", "gql.tada": "bin/cli.js" } }, "sha512-1LMiA46dRs5oF7Qev6vMU32gmiNvM3+3nHoQZA9K9j2xQzH8xOAWnnJrLSbZOFHTSdFxqn86TL6beo1/7ja/aA=="],
+
+    "graphql": ["graphql@16.13.0", "", {}, "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "nanoresource": ["nanoresource@1.3.0", "", { "dependencies": { "inherits": "^2.0.4" } }, "sha512-OI5dswqipmlYfyL3k/YMm7mbERlh4Bd1KuKdMHpeoVD1iVxqxaTMKleB4qaA2mbQZ6/zMNSxCXv9M9P/YbqTuQ=="],
+
+    "napi-macros": ["napi-macros@2.2.2", "", {}, "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "poseidon-lite": ["poseidon-lite@0.2.1", "", {}, "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog=="],
+
+    "prettier": ["prettier@3.8.1", "", { "bin": "bin/prettier.cjs" }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" } }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@mysten/bcs/@mysten/utils": ["@mysten/utils@0.3.1", "", { "dependencies": { "@scure/base": "^2.0.0" } }, "sha512-36KhxG284uhDdSnlkyNaS6fzKTX9FpP2WQWOwUKIRsqQFFIm2ooCf2TP1IuqrtMpkairwpiWkAS0eg7cpemVzg=="],
+
+    "@mysten/bcs/@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
+
+    "@mysten/codegen/@mysten/sui": ["@mysten/sui@2.5.1", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@mysten/bcs": "^2.0.2", "@mysten/utils": "^0.3.1", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@protobuf-ts/grpcweb-transport": "^2.11.1", "@protobuf-ts/runtime": "^2.11.1", "@protobuf-ts/runtime-rpc": "^2.11.1", "@scure/base": "^2.0.0", "@scure/bip32": "^2.0.1", "@scure/bip39": "^2.0.1", "gql.tada": "^1.9.0", "graphql": "^16.12.0", "poseidon-lite": "0.2.1", "valibot": "^1.2.0" } }, "sha512-M2FTtgrbzyC9nIbPj25S476FZah952S2WIusJRrLt7RcfPqztlqAoqQt49jBBRIgkGNxhK3DcKZ/RzQUbuCD9w=="],
+
+    "@mysten/codegen/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+
+    "@mysten/sui/@mysten/bcs": ["@mysten/bcs@1.9.2", "", { "dependencies": { "@mysten/utils": "0.2.0", "@scure/base": "^1.2.6" } }, "sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ=="],
+
+    "bun-types/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+
+    "@mysten/codegen/@mysten/sui/@mysten/utils": ["@mysten/utils@0.3.1", "", { "dependencies": { "@scure/base": "^2.0.0" } }, "sha512-36KhxG284uhDdSnlkyNaS6fzKTX9FpP2WQWOwUKIRsqQFFIm2ooCf2TP1IuqrtMpkairwpiWkAS0eg7cpemVzg=="],
+
+    "@mysten/codegen/@mysten/sui/@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
+
+    "@mysten/codegen/@mysten/sui/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
+    "@mysten/codegen/@mysten/sui/@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
+
+    "@mysten/codegen/@mysten/sui/@scure/bip32": ["@scure/bip32@2.0.1", "", { "dependencies": { "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA=="],
+
+    "@mysten/codegen/@mysten/sui/@scure/bip39": ["@scure/bip39@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg=="],
+
+    "@mysten/codegen/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -4,18 +4,17 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "bun run --bun tsc",
     "codegen": "sui-ts-codegen generate",
-    "start": "node dist/index.js"
+    "start": "bun run src/index.ts"
   },
   "dependencies": {
     "@mysten/sui": "^1.0.0",
-    "better-sqlite3": "^11.0.0",
     "fuse-native": "^2.2.2"
   },
   "devDependencies": {
     "@mysten/codegen": "^0.8.2",
-    "@types/better-sqlite3": "^7.6.0",
+    "@types/bun": "^1.2.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.7.0"
   }

--- a/app/src/fuse.ts
+++ b/app/src/fuse.ts
@@ -1,5 +1,228 @@
-/** FUSE filesystem operations — maps Finder actions to Walrus + SQLite. */
+/**
+ * FUSE filesystem thin client — delegates every VFS operation to a local HTTP
+ * server via JSON RPC. This decouples the kernel-facing FUSE layer from
+ * storage/encryption logic, making both independently testable.
+ */
 
-export function mountDrive(_mountPoint: string) {
-  // TODO: implement FUSE ops (read, write, readdir, getattr, etc.)
+import Fuse from "fuse-native";
+import { execSync } from "child_process";
+import { resolve } from "path";
+
+// ── Constants ───────────────────────────────────────────────
+
+const DEFAULT_BASE_URL = "http://localhost:3001";
+const FETCH_TIMEOUT_MS = 30_000;
+
+// ── Error mapping ───────────────────────────────────────────
+
+const ERROR_MAP: Record<string, number> = {
+  EPERM: Fuse.EPERM,
+  ENOENT: Fuse.ENOENT,
+  EIO: Fuse.EIO,
+  EACCES: Fuse.EACCES,
+  EBUSY: Fuse.EBUSY,
+  EEXIST: Fuse.EEXIST,
+  ENOTDIR: Fuse.ENOTDIR,
+  EISDIR: Fuse.EISDIR,
+  EINVAL: Fuse.EINVAL,
+  ENOSPC: Fuse.ENOSPC,
+  EROFS: Fuse.EROFS,
+  ENOSYS: Fuse.ENOSYS,
+  ENOTEMPTY: Fuse.ENOTEMPTY,
+};
+
+class FuseHttpError extends Error {
+  code: number;
+  constructor(errorName: string) {
+    super(`FUSE error: ${errorName}`);
+    this.code = ERROR_MAP[errorName] ?? Fuse.EIO;
+  }
+}
+
+// ── HTTP helper ─────────────────────────────────────────────
+
+async function fetchOp(
+  baseUrl: string,
+  op: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${baseUrl}/fuse/${op}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+
+  const json = (await res.json()) as Record<string, unknown>;
+
+  if (!res.ok) {
+    const errorName =
+      typeof json.error === "string" ? json.error : "EIO";
+    throw new FuseHttpError(errorName);
+  }
+
+  return json;
+}
+
+// ── Stat parsing ────────────────────────────────────────────
+
+function parseStat(raw: Record<string, unknown>): Fuse.FuseStats {
+  return {
+    mode: raw.mode as number,
+    uid: raw.uid as number,
+    gid: raw.gid as number,
+    size: raw.size as number,
+    dev: (raw.dev as number) ?? 0,
+    nlink: (raw.nlink as number) ?? 1,
+    ino: (raw.ino as number) ?? 0,
+    rdev: (raw.rdev as number) ?? 0,
+    blksize: (raw.blksize as number) ?? 4096,
+    blocks: (raw.blocks as number) ?? 0,
+    atime: new Date(raw.atime as string),
+    mtime: new Date(raw.mtime as string),
+    ctime: new Date(raw.ctime as string),
+  };
+}
+
+// ── FUSE operations ─────────────────────────────────────────
+
+function createOps(baseUrl: string): Fuse.FuseOperations {
+  return {
+    getattr(path, cb) {
+      fetchOp(baseUrl, "getattr", { path })
+        .then((json) => {
+          const stat = parseStat(json.stat as Record<string, unknown>);
+          cb(0, stat);
+        })
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    readdir(path, cb) {
+      fetchOp(baseUrl, "readdir", { path })
+        .then((json) => cb(0, json.entries as string[]))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    open(path, flags, cb) {
+      fetchOp(baseUrl, "open", { path, flags })
+        .then((json) => cb(0, json.fd as number))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    // read callback: cb(bytesRead) — 0 = EOF, negative = error
+    read(path, fd, buffer, length, position, cb) {
+      fetchOp(baseUrl, "read", { path, fd, length, position })
+        .then((json) => {
+          const b64 = json.data as string;
+          const bytesRead = json.bytesRead as number;
+          if (bytesRead === 0) return cb(0);
+          const decoded = Buffer.from(b64, "base64");
+          decoded.copy(buffer, 0, 0, bytesRead);
+          cb(bytesRead);
+        })
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    // write callback: cb(bytesWritten) — negative = error
+    write(path, fd, buffer, length, position, cb) {
+      const data = buffer.subarray(0, length).toString("base64");
+      fetchOp(baseUrl, "write", { path, fd, data, length, position })
+        .then((json) => cb(json.bytesWritten as number))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    create(path, mode, cb) {
+      fetchOp(baseUrl, "create", { path, mode })
+        .then((json) => cb(0, json.fd as number))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    unlink(path, cb) {
+      fetchOp(baseUrl, "unlink", { path })
+        .then(() => cb(0))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    rename(src, dest, cb) {
+      fetchOp(baseUrl, "rename", { src, dest })
+        .then(() => cb(0))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    mkdir(path, mode, cb) {
+      fetchOp(baseUrl, "mkdir", { path, mode })
+        .then(() => cb(0))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    rmdir(path, cb) {
+      fetchOp(baseUrl, "rmdir", { path })
+        .then(() => cb(0))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    truncate(path, size, cb) {
+      fetchOp(baseUrl, "truncate", { path, size })
+        .then(() => cb(0))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+
+    release(path, fd, cb) {
+      fetchOp(baseUrl, "release", { path, fd })
+        .then(() => cb(0))
+        .catch((e: FuseHttpError) => cb(e.code ?? Fuse.EIO));
+    },
+  };
+}
+
+// ── Mount entrypoint ────────────────────────────────────────
+
+export function mountDrive(
+  mountPoint: string,
+  baseUrl: string = DEFAULT_BASE_URL,
+): Promise<void> {
+  const mnt = resolve(mountPoint);
+  const ops = createOps(baseUrl);
+
+  const fuse = new Fuse(mnt, ops, {
+    debug: false,
+    force: true,
+    mkdir: true,
+  });
+
+  return new Promise<void>((resolveP, reject) => {
+    fuse.mount((err) => {
+      if (err) {
+        reject(new Error(`Mount failed: ${err.message}`));
+        return;
+      }
+
+      console.log(`walrus-drive mounted at ${mnt}`);
+      console.log(`  backend: ${baseUrl}`);
+      console.log("  press Ctrl+C to unmount");
+
+      const cleanup = () => {
+        console.log("\nunmounting…");
+        fuse.unmount((unmountErr) => {
+          if (unmountErr) {
+            console.error(
+              "unmount failed, forcing:",
+              unmountErr.message,
+            );
+            try {
+              execSync(`diskutil unmount force "${mnt}"`);
+            } catch {
+              // best-effort
+            }
+          }
+          process.exit(0);
+        });
+      };
+
+      process.on("SIGINT", cleanup);
+      process.on("SIGTERM", cleanup);
+
+      resolveP();
+    });
+  });
 }

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -1,6 +1,9 @@
+import { mountDrive } from "./fuse.ts";
+
 export async function main() {
   console.log("walrus-drive starting…");
-  // TODO: init DB, mount FUSE, start daemon
+  const mountPoint = process.argv[2] || "./mnt";
+  await mountDrive(mountPoint);
 }
 
 main();

--- a/app/src/types/fuse-native.d.ts
+++ b/app/src/types/fuse-native.d.ts
@@ -1,0 +1,176 @@
+declare module "fuse-native" {
+  namespace Fuse {
+    interface FuseStats {
+      mode: number;
+      uid: number;
+      gid: number;
+      size: number;
+      dev: number;
+      nlink: number;
+      ino: number;
+      rdev: number;
+      blksize: number;
+      blocks: number;
+      atime: Date;
+      mtime: Date;
+      ctime: Date;
+    }
+
+    interface FuseStatFS {
+      bsize: number;
+      frsize: number;
+      blocks: number;
+      bfree: number;
+      bavail: number;
+      files: number;
+      ffree: number;
+      favail: number;
+      fsid: number;
+      flag: number;
+      namemax: number;
+    }
+
+    interface FuseOperations {
+      init?(cb: (err: number) => void): void;
+      access?(path: string, mode: number, cb: (err: number) => void): void;
+      statfs?(
+        path: string,
+        cb: (err: number, stats?: FuseStatFS) => void,
+      ): void;
+      getattr?(
+        path: string,
+        cb: (err: number, stat?: FuseStats) => void,
+      ): void;
+      fgetattr?(
+        path: string,
+        fd: number,
+        cb: (err: number, stat?: FuseStats) => void,
+      ): void;
+      readdir?(
+        path: string,
+        cb: (err: number, names?: string[]) => void,
+      ): void;
+      open?(
+        path: string,
+        flags: number,
+        cb: (err: number, fd?: number) => void,
+      ): void;
+      read?(
+        path: string,
+        fd: number,
+        buffer: Buffer,
+        length: number,
+        position: number,
+        cb: (bytesRead: number) => void,
+      ): void;
+      write?(
+        path: string,
+        fd: number,
+        buffer: Buffer,
+        length: number,
+        position: number,
+        cb: (bytesWritten: number) => void,
+      ): void;
+      release?(path: string, fd: number, cb: (err: number) => void): void;
+      create?(
+        path: string,
+        mode: number,
+        cb: (err: number, fd?: number) => void,
+      ): void;
+      unlink?(path: string, cb: (err: number) => void): void;
+      rename?(src: string, dest: string, cb: (err: number) => void): void;
+      mkdir?(path: string, mode: number, cb: (err: number) => void): void;
+      rmdir?(path: string, cb: (err: number) => void): void;
+      truncate?(path: string, size: number, cb: (err: number) => void): void;
+      chmod?(path: string, mode: number, cb: (err: number) => void): void;
+      chown?(
+        path: string,
+        uid: number,
+        gid: number,
+        cb: (err: number) => void,
+      ): void;
+      utimens?(
+        path: string,
+        atime: Date,
+        mtime: Date,
+        cb: (err: number) => void,
+      ): void;
+      link?(src: string, dest: string, cb: (err: number) => void): void;
+      symlink?(src: string, dest: string, cb: (err: number) => void): void;
+      readlink?(
+        path: string,
+        cb: (err: number, linkName?: string) => void,
+      ): void;
+      flush?(path: string, fd: number, cb: (err: number) => void): void;
+      fsync?(
+        path: string,
+        dataSync: boolean,
+        fd: number,
+        cb: (err: number) => void,
+      ): void;
+      setxattr?(
+        path: string,
+        name: string,
+        value: Buffer,
+        size: number,
+        flags: number,
+        cb: (err: number) => void,
+      ): void;
+      getxattr?(
+        path: string,
+        name: string,
+        size: number,
+        cb: (err: number) => void,
+      ): void;
+      listxattr?(
+        path: string,
+        cb: (err: number, list?: string[]) => void,
+      ): void;
+      removexattr?(
+        path: string,
+        name: string,
+        cb: (err: number) => void,
+      ): void;
+    }
+
+    interface FuseOptions {
+      debug?: boolean;
+      force?: boolean;
+      mkdir?: boolean;
+      displayFolder?: string;
+      allowOther?: boolean;
+      autoUnmount?: boolean;
+      fsname?: string;
+      uid?: number;
+      gid?: number;
+    }
+  }
+
+  class Fuse {
+    constructor(
+      mnt: string,
+      ops: Fuse.FuseOperations,
+      opts?: Fuse.FuseOptions,
+    );
+    mount(cb: (err: Error | null) => void): void;
+    unmount(cb: (err: Error | null) => void): void;
+    static unmount(mnt: string, cb: (err: Error | null) => void): void;
+
+    // POSIX error codes (negated)
+    static EPERM: -1;
+    static ENOENT: -2;
+    static EIO: -5;
+    static EACCES: -13;
+    static EBUSY: -16;
+    static EEXIST: -17;
+    static ENOTDIR: -20;
+    static EISDIR: -21;
+    static EINVAL: -22;
+    static ENOSPC: -28;
+    static EROFS: -30;
+    static ENOSYS: -38;
+    static ENOTEMPTY: -39;
+  }
+
+  export = Fuse;
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "outDir": "dist",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Scaffold the FUSE filesystem as an HTTP thin client that delegates all 12 VFS operations to a local server via JSON RPC (POST localhost:3001/fuse/{op}). Switch the project from Node to Bun runtime with bundler module resolution.

- Add fuse-native TypeScript declarations with namespace merging
- Implement all FUSE ops: getattr, readdir, open, read, write, create, unlink, rename, mkdir, rmdir, truncate, release
- Base64 encode binary data for read/write over JSON
- 30s fetch timeout + graceful unmount with diskutil fallback
- Update tsconfig for Bun (preserve module, bundler resolution, noEmit)
- Update package.json scripts to use bun, drop better-sqlite3
- Wire mountDrive() in index.ts with CLI mount point arg
- Add CLAUDE.md with project context and architecture docs